### PR TITLE
Fail gracefully if 'buster-core' not found

### DIFF
--- a/lib/buster-format.js
+++ b/lib/buster-format.js
@@ -1,7 +1,9 @@
 var buster = this.buster || {};
 
 if (typeof require != "undefined") {
-    buster = require("buster-core");
+    try {
+        buster = require("buster-core");
+    } catch(e) {/* silent */}
 }
 
 buster.format = buster.format || {};


### PR DESCRIPTION
This issue affects SinonJS project (https://github.com/cjohansen/Sinon.JS), because of buster-format.js is fully copied to sinon.js during build.
**Details:** https://github.com/cjohansen/Sinon.JS/issues/77
