### PR TITLE
Run CI tests in newer nodes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 sudo: false
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
-  - "5"
+  - "6"
+  - "8"
 before_install:
   - npm i -g npm


### PR DESCRIPTION
Dependencies are no longer supporting `0.10` and `0.12`