### PR TITLE
Add prepublishOnly task to ensure fresh documentation on new release

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "lint": "eslint .",
+    "prepublishOnly": "mkdocs gh-deploy -r upstream || mkdocs gh-deploy -r origin",
     "test": "mocha 'lib/**/*.test.js'",
     "test-coverage": "nyc --reporter text --reporter html --reporter lcovonly npm run test"
   },


### PR DESCRIPTION
This means that we will always publish new documentation to GitHub pages whenever a new release is cut