### PR TITLE
Samsam v2 or v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,14 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/commons": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz",
+      "integrity": "sha512-WR3dlgqJP4QNrLC4iXN/5/2WaLQQ0VijOOkmflqFGVJ6wLEpbSjo7c0ZeGIdtY8Crk7xBBp87sM6+Mkerz7alw==",
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
     "@sinonjs/formatio": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz",
@@ -38,12 +46,25 @@
         "lodash.includes": "^4.3.0",
         "lodash.isarguments": "^3.1.0",
         "object-assign": "^4.1.1"
+      },
+      "dependencies": {
+        "@sinonjs/samsam": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.3.tgz",
+          "integrity": "sha512-8zNeBkSKhU9a5cRNbpCKau2WWPfan+Q2zDlcXvXyhn9EsMqgYs4qzo0XHNVlXC6ABQL8fT6nV+zzo5RTHJzyXw==",
+          "dev": true
+        }
       }
     },
     "@sinonjs/samsam": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.3.tgz",
-      "integrity": "sha512-8zNeBkSKhU9a5cRNbpCKau2WWPfan+Q2zDlcXvXyhn9EsMqgYs4qzo0XHNVlXC6ABQL8fT6nV+zzo5RTHJzyXw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.0.0.tgz",
+      "integrity": "sha512-HYQiZXtwBEtjLPPZ3/X/wiKFNY9fMrJEjdSvYfeUEgTmppNVuDVQKIYGNTdM08sHkfes17KaE0RLOwHSbA0/ww==",
+      "requires": {
+        "@sinonjs/commons": "1.0.2",
+        "array-from": "^2.1.1",
+        "lodash.get": "4.4.2"
+      }
     },
     "@types/estree": {
       "version": "0.0.39",
@@ -143,8 +164,7 @@
     "array-from": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
-      "dev": true
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
     },
     "array-union": {
       "version": "1.0.2",
@@ -1039,6 +1059,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -4315,6 +4340,11 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test-coverage": "nyc --reporter text --reporter html --reporter lcovonly npm run test"
   },
   "dependencies": {
-    "@sinonjs/samsam": "^2.1.3"
+    "@sinonjs/samsam": "^2 || ^3"
   },
   "devDependencies": {
     "@sinonjs/referee": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@sinonjs/formatio",
   "version": "3.0.1",
   "description": "Human-readable object formatting",
-  "homepage": "http://busterjs.org/docs/formatio/",
+  "homepage": "https://sinonjs.github.io/formatio/",
   "author": "Christian Johansen",
   "license": "BSD-3-Clause",
   "main": "./lib/formatio",


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Upgrade samsam to `^2 || ^3` and fix homepage URL in `package.json`. This means samsam will be installed by default, but we're still compatible with v2, so that this does not have to be a major release.

#### Background (Problem in detail)  - optional

To avoid having multiple versions of samsam, I'd like cut a new major with samsam v3 here for referee and sinon to depend on.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm t`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
