### PR TITLE
refactor: use functionality from commons package

### DIFF
--- a/lib/formatio.js
+++ b/lib/formatio.js
@@ -1,6 +1,9 @@
 "use strict";
 
 var samsam = require("@sinonjs/samsam");
+var functionName = require("@sinonjs/commons").functionName;
+var typeOf = require("@sinonjs/commons").typeOf;
+
 var formatio = {
     excludeConstructors: ["Object", /^.$/],
     quoteStrings: true,
@@ -19,14 +22,6 @@ if (typeof document !== "undefined") {
 }
 if (typeof window !== "undefined") {
     specialObjects.push({ object: window, value: "[object Window]" });
-}
-
-function functionName(func) {
-    if (!func) { return ""; }
-    if (func.displayName) { return func.displayName; }
-    if (func.name) { return func.name; }
-    var matches = func.toString().match(/function\s+([^\(]+)/m);
-    return (matches && matches[1]) || "";
 }
 
 function constructorName(f, object) {
@@ -71,7 +66,7 @@ function ascii(f, object, processed, indent) {
 
     if (isCircular(object, processed)) { return "[Circular]"; }
 
-    if (Object.prototype.toString.call(object) === "[object Array]") {
+    if (typeOf(object) === "array") {
         return ascii.array.call(f, object, processed);
     }
 
@@ -98,7 +93,8 @@ function ascii(f, object, processed, indent) {
 }
 
 ascii.func = function (func) {
-    return "function " + functionName(func) + "() {}";
+    var funcName = functionName(func) || "";
+    return "function " + funcName + "() {}";
 };
 
 function delimit(str, delimiters) {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test-coverage": "nyc --reporter text --reporter html --reporter lcovonly npm run test"
   },
   "dependencies": {
+    "@sinonjs/commons": "^1",
     "@sinonjs/samsam": "^2 || ^3"
   },
   "devDependencies": {


### PR DESCRIPTION


#### Purpose (TL;DR) - mandatory

* add `@sinonjs/commons`
* replace `functionName` method with implementation from `@sinonjs/commons`
* use `typeOf` for array identification

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
