### PR TITLE
build: add coverage folder to eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 dist/
+coverage/


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

As of all projects add the `coverage` folder to `.eslintignore` to be not linted

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm run test-coverage`
4. `npm run lint`
5. See no lint errors anymore 😉 

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
