### PR TITLE
Format symbols

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -6,6 +6,7 @@ env:
 
 globals:
   Set: false
+  Symbol: false
 
 plugins:
   - ie11

--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Dominykas Blyžė <hello@dominykas.com>
 Edward Betts <edward@4angle.com>
 Dave Geddes <davidcgeddes@gmail.com>
 Stein Magnus Jodal <stein.magnus@jodal.no>
+Brandon Evans <contact@brandonmevans.com>

--- a/lib/formatio.js
+++ b/lib/formatio.js
@@ -153,7 +153,7 @@ ascii.object = function (object, processed, indent) {
         }
 
         str = (
-            typeof prop === 'string' && /\s/.test(prop) ?
+            typeof prop === "string" && /\s/.test(prop) ?
                 "\"" + prop + "\"" : prop.toString()
         ) + ": " + str;
         length += str.length;

--- a/lib/formatio.js
+++ b/lib/formatio.js
@@ -63,6 +63,10 @@ function ascii(f, object, processed, indent) {
         return processed || quote ? "\"" + object + "\"" : object;
     }
 
+    if (typeof object === "symbol") {
+        return object.toString();
+    }
+
     if (typeof object === "function" && !(object instanceof RegExp)) {
         return ascii.func(object);
     }
@@ -134,7 +138,9 @@ ascii.object = function (object, processed, indent) {
     processed.push(object);
     indent = indent || 0;
     var pieces = [];
-    var properties = Object.keys(object).sort();
+    var properties = Object.keys(object).sort().concat(
+        Object.getOwnPropertySymbols(object)
+    );
     var length = 3;
     var prop, str, obj, i, k, l;
     l = (this.limitChildrenCount > 0) ?
@@ -143,6 +149,10 @@ ascii.object = function (object, processed, indent) {
     for (i = 0; i < l; ++i) {
         prop = properties[i];
         obj = object[prop];
+
+        if (typeof object === "symbol") {
+            return object.toString();
+        }
 
         if (isCircular(obj, processed)) {
             str = "[Circular]";

--- a/lib/formatio.js
+++ b/lib/formatio.js
@@ -150,17 +150,16 @@ ascii.object = function (object, processed, indent) {
         prop = properties[i];
         obj = object[prop];
 
-        if (typeof object === "symbol") {
-            return object.toString();
-        }
-
         if (isCircular(obj, processed)) {
             str = "[Circular]";
         } else {
             str = ascii(this, obj, processed, indent + 2);
         }
 
-        str = (/\s/.test(prop) ? "\"" + prop + "\"" : prop) + ": " + str;
+        str = (
+            typeof prop === 'string' && /\s/.test(prop) ?
+                "\"" + prop + "\"" : prop.toString()
+        ) + ": " + str;
         length += str.length;
         pieces.push(str);
     }

--- a/lib/formatio.test.js
+++ b/lib/formatio.test.js
@@ -379,6 +379,10 @@ describe("formatio.ascii", function () {
         });
     });
 
+    it("formats symbol", function () {
+        assert.equals(formatio.ascii(Symbol("value")), "Symbol(value)");
+    });
+
     describe("sets", function () {
         it("formats sets", function () {
             var set = new Set();

--- a/lib/formatio.test.js
+++ b/lib/formatio.test.js
@@ -198,7 +198,7 @@ describe("formatio.ascii", function () {
             "oh hi": 42,
             seriously: "many properties"
         };
-        object[Symbol("symbolic")] = "symbolic property";
+        object[Symbol("key")] = Symbol("value");
 
         var expectedFunctionString =
             namesAnonymousFunctions
@@ -209,7 +209,7 @@ describe("formatio.ascii", function () {
                 "more: \"properties\",\n  \"oh hi\": 42,\n  please: " +
                 "\"Gimme some more\",\n  prop: \"Some\"," +
                 "\n  seriously: \"many properties\"," +
-                "\n  Symbol(symbolic): \"symbolic property\"\n}";
+                "\n  Symbol(key): Symbol(value)\n}";
 
         assert.equals(formatio.ascii(object), expected);
     });

--- a/lib/formatio.test.js
+++ b/lib/formatio.test.js
@@ -198,6 +198,7 @@ describe("formatio.ascii", function () {
             "oh hi": 42,
             seriously: "many properties"
         };
+        object[Symbol("symbolic")] = "symbolic property";
 
         var expectedFunctionString =
             namesAnonymousFunctions
@@ -207,7 +208,8 @@ describe("formatio.ascii", function () {
         var expected = "{\n  " + expectedFunctionString + ",\n  id: 42,\n  " +
                 "more: \"properties\",\n  \"oh hi\": 42,\n  please: " +
                 "\"Gimme some more\",\n  prop: \"Some\"," +
-                "\n  seriously: \"many properties\"\n}";
+                "\n  seriously: \"many properties\"," +
+                "\n  Symbol(symbolic): \"symbolic property\"\n}";
 
         assert.equals(formatio.ascii(object), expected);
     });


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Properly format [JavaScript symbols](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol). Related to [sinon#1974](https://github.com/sinonjs/sinon/issues/1974).

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`. This PR adds a symbolic key to one of the objects in a unit test and verifies that it is rendered properly.

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
