### PR TITLE
Feature detect Object.getOwnPropertySymbols

### DIFF
--- a/lib/formatio.js
+++ b/lib/formatio.js
@@ -134,9 +134,10 @@ ascii.object = function (object, processed, indent) {
     processed.push(object);
     indent = indent || 0;
     var pieces = [];
-    var properties = Object.keys(object).sort().concat(
-        Object.getOwnPropertySymbols(object)
-    );
+    var symbols = typeof Object.getOwnPropertySymbols === "function"
+        ? Object.getOwnPropertySymbols(object)
+        : [];
+    var properties = Object.keys(object).sort().concat(symbols);
     var length = 3;
     var prop, str, obj, i, k, l;
     l = (this.limitChildrenCount > 0) ?


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

This fixes an IE 11 regression introduced in #26. `Object.getOwnPropertySymbols` is not supported in all environments.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm t`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).