### PR TITLE
add support for bigint formatting

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -7,6 +7,7 @@ env:
 globals:
   Set: false
   Symbol: false
+  BigInt: false
 
 plugins:
   - ie11

--- a/lib/formatio.js
+++ b/lib/formatio.js
@@ -66,6 +66,13 @@ function ascii(f, object, processed, indent) {
         return ascii.func(object);
     }
 
+    // eslint supports bigint as of version 6.0.0
+    // https://github.com/eslint/eslint/commit/e4ab0531c4e44c23494c6a802aa2329d15ac90e5
+    // eslint-disable-next-line
+    if (typeof BigInt !== "undefined" && typeof object === "bigint") {
+        return object.toString();
+    }
+
     processed = processed || [];
 
     if (isCircular(object, processed)) { return "[Circular]"; }

--- a/lib/formatio.js
+++ b/lib/formatio.js
@@ -69,7 +69,7 @@ function ascii(f, object, processed, indent) {
     // eslint supports bigint as of version 6.0.0
     // https://github.com/eslint/eslint/commit/e4ab0531c4e44c23494c6a802aa2329d15ac90e5
     // eslint-disable-next-line
-    if (typeof BigInt !== "undefined" && typeof object === "bigint") {
+    if (typeOf(object) === "bigint") {
         return object.toString();
     }
 

--- a/lib/formatio.test.js
+++ b/lib/formatio.test.js
@@ -527,9 +527,11 @@ describe("formatio.ascii", function () {
     });
 
     describe("BigInt", function () {
-        if (typeof BigInt === "undefined") {
-            return;
-        }
+        before(function () {
+            if (typeof BigInt === "undefined") {
+                this.skip();
+            }
+        });
 
         // Note: We cannot use 0n, 1n, -1n here because not all
         // browsers and node versions support BigInt at the moment

--- a/lib/formatio.test.js
+++ b/lib/formatio.test.js
@@ -525,4 +525,29 @@ describe("formatio.ascii", function () {
             assert.equals(str, "[object global]");
         });
     });
+
+    describe("BigInt", function () {
+        if (typeof BigInt === "undefined") {
+            return;
+        }
+
+        // Note: We cannot use 0n, 1n, -1n here because not all
+        // browsers and node versions support BigInt at the moment
+        // and this will result in a SyntaxError
+
+        it("formats 0n", function () {
+            // eslint-disable-next-line
+            assert.equals(formatio.ascii(BigInt("0")), "0");
+        });
+
+        it("formats positive values", function () {
+            // eslint-disable-next-line
+            assert.equals(formatio.ascii(BigInt("1")), "1");
+        });
+
+        it("formats negative values", function () {
+            // eslint-disable-next-line
+            assert.equals(formatio.ascii(BigInt("-1")), "-1");
+        });
+    });
 });


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

This PR adds support for [`BigInt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) and fixes #30.

Tested on Node `9.4.0` and `10.16.0`

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
