### PR TITLE
Format arguments without @@iterator

### DIFF
--- a/lib/formatio.js
+++ b/lib/formatio.js
@@ -136,15 +136,24 @@ ascii.set = function (set, processed) {
     return ascii.array.call(this, Array.from(set), processed, ["Set {", "}"]);
 };
 
+function getSymbols(object) {
+    if (samsam.isArguments(object)) {
+        return [];
+    }
+
+    if (typeof Object.getOwnPropertySymbols === "function") {
+        return Object.getOwnPropertySymbols(object);
+    }
+
+    return [];
+}
+
 ascii.object = function (object, processed, indent) {
     processed = processed || [];
     processed.push(object);
     indent = indent || 0;
     var pieces = [];
-    var symbols = typeof Object.getOwnPropertySymbols === "function"
-        ? Object.getOwnPropertySymbols(object)
-        : [];
-    var properties = Object.keys(object).sort().concat(symbols);
+    var properties = Object.keys(object).sort().concat(getSymbols(object));
     var length = 3;
     var prop, str, obj, i, k, l;
     l = (this.limitChildrenCount > 0) ?

--- a/lib/formatio.test.js
+++ b/lib/formatio.test.js
@@ -552,4 +552,12 @@ describe("formatio.ascii", function () {
             assert.equals(formatio.ascii(BigInt("-1")), "-1");
         });
     });
+
+    describe("arguments", function () {
+        it("excludes the values method", function () {
+            var str = formatio.ascii(arguments);
+
+            assert.equals(str, "{  }");
+        });
+    });
 });


### PR DESCRIPTION
The @@iterator is the same as `Array.prototype.values`.

The changes introduced in ff37cfd46270cc15939eff51a9c014e4e37b296b
causes the ascii method to render `arguments` differently, breaking
backwards compatibility.

This breaks dependents that use formatio to format the arguments object,
such as `@sinonjs/referee`.

Solution: detect arguments object and ignore any symbols on it.

See:
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments/@@iterator
