### PR TITLE
add support for formatting maps

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -5,6 +5,7 @@ env:
   node: true
 
 globals:
+  Map: false
   Set: false
   Symbol: false
   BigInt: false

--- a/lib/formatio.js
+++ b/lib/formatio.js
@@ -116,6 +116,10 @@ function ascii(f, object, processed, indent) {
         return ascii.set.call(f, object, internalProcessed);
     }
 
+    if (object instanceof Map) {
+        return ascii.map.call(f, object, internalProcessed);
+    }
+
     return ascii.object.call(f, object, internalProcessed, indent);
 }
 
@@ -151,6 +155,10 @@ ascii.array = function(array, processed, delimiters) {
 
 ascii.set = function(set, processed) {
     return ascii.array.call(this, Array.from(set), processed, ["Set {", "}"]);
+};
+
+ascii.map = function(map, processed) {
+    return ascii.array.call(this, Array.from(map), processed, ["Map [", "]"]);
 };
 
 function getSymbols(object) {

--- a/lib/formatio.test.js
+++ b/lib/formatio.test.js
@@ -463,6 +463,37 @@ describe("formatio.ascii", function() {
         });
     });
 
+    describe("maps", function() {
+        it("formats maps", function() {
+            var map = new Map();
+
+            map.set(42, "foo");
+            map.set("sinon", "bar");
+            map.set({ foo: "bar" }, "baz");
+
+            assert.equals(
+                formatio.ascii(map),
+                // eslint-disable-next-line quotes
+                'Map [[42, "foo"], ["sinon", "bar"], [{ foo: "bar" }, "baz"]]'
+            );
+        });
+
+        it("limits the number of map memebers", function() {
+            var fmt = formatio.configure({ limitChildrenCount: 30 });
+            var map = new Map();
+
+            for (var i = 0; i < 300; i++) {
+                map.set(i, "some value");
+            }
+
+            var str = fmt.ascii(map);
+
+            refute.contains(str, "30");
+            assert.contains(str, "29");
+            assert.contains(str, "[... 270 more elements]");
+        });
+    });
+
     describe("unquoted strings", function() {
         beforeEach(function() {
             this.formatter = formatio.configure({ quoteStrings: false });

--- a/lib/formatio.test.js
+++ b/lib/formatio.test.js
@@ -478,7 +478,7 @@ describe("formatio.ascii", function() {
             );
         });
 
-        it("limits the number of map memebers", function() {
+        it("limits the number of map members", function() {
             var fmt = formatio.configure({ limitChildrenCount: 30 });
             var map = new Map();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -145,6 +145,19 @@
       "requires": {
         "@sinonjs/commons": "^1",
         "@sinonjs/samsam": "^3.1.0"
+      },
+      "dependencies": {
+        "@sinonjs/samsam": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+          "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.3.0",
+            "array-from": "^2.1.1",
+            "lodash": "^4.17.15"
+          }
+        }
       }
     },
     "@sinonjs/referee": {
@@ -171,17 +184,28 @@
           "requires": {
             "type-detect": "4.0.8"
           }
+        },
+        "@sinonjs/samsam": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+          "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.3.0",
+            "array-from": "^2.1.1",
+            "lodash": "^4.17.15"
+          }
         }
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
-      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-4.2.0.tgz",
+      "integrity": "sha512-yG7QbUz38ZPIegfuSMEcbOo0kkLGmPa8a0Qlz4dk7+cXYALDScWjIZzAm/u2+Frh+bcdZF6wZJZwwuJjY0WAjA==",
       "requires": {
-        "@sinonjs/commons": "^1.3.0",
+        "@sinonjs/commons": "^1.6.0",
         "array-from": "^2.1.1",
-        "lodash": "^4.17.15"
+        "lodash.get": "^4.4.2"
       }
     },
     "@types/estree": {
@@ -1811,13 +1835,19 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.includes": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@sinonjs/commons": "^1",
-    "@sinonjs/samsam": "^3.1.0"
+    "@sinonjs/samsam": "^4.2.0"
   },
   "devDependencies": {
     "@sinonjs/referee": "^3.2.0",


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

This PR adds support for formatting [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map).

❗️ This waits for sinonjs/samsam#124 to use `samsam.isMap` in https://github.com/sinonjs/formatio/pull/51/files#diff-f62046d6a7ef22f4caadca5534824f25R119

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
