### PR TITLE
Drop support for Node 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,15 +48,6 @@ jobs:
           name: lint
           command: npm run lint
 
-  node-8:
-    docker:
-      - image: circleci/node:8
-    steps:
-      - *attach-step
-      - run:
-          name: Test
-          command: npm test
-
   node-10:
     docker:
       - image: circleci/node:10
@@ -78,6 +69,15 @@ jobs:
           name: Upload coverage report
           command: bash <(curl -s https://codecov.io/bash) -F unit -s coverage/lcov.info
 
+  node-13:
+    docker:
+      - image: circleci/node:13
+    steps:
+      - *attach-step
+      - run:
+          name: Test
+          command: npm test
+
 workflows:
   version: 2
   formatio:
@@ -86,12 +86,12 @@ workflows:
       - lint:
           requires:
             - install-dependencies
-      - node-8:
-          requires:
-            - install-dependencies
       - node-10:
           requires:
             - install-dependencies
       - node-12:
+          requires:
+            - install-dependencies
+      - node-13:
           requires:
             - install-dependencies


### PR DESCRIPTION
As can be seen at https://github.com/nodejs/Release, Node 8 reached
"end" of life on 2019-12-31, and is no longer actively supported.

We will stop testing in Node 8 and start testing in Node 13, which will become the next LTS release from April 2020.

#### How to verify - mandatory

1. Navigate to the test summary box below this one
2. Observe that we're no longer testing in Node 8
3. Observe that we are now also testing in Node 13

alternatively,

1. Navigate to the [Circle workflow for this PR](https://circleci.com/workflow-run/f275043f-1037-4a4a-99ac-10956a974083?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link)
2. Observe that we're no longer testing in Node 8
3. Observe that we are now also testing in Node 13

![2020-02-05 at 14 53](https://user-images.githubusercontent.com/20321/73852606-5da15500-4827-11ea-9421-a7270d41413f.png)
